### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+require:
+  - rubocop-packaging

--- a/rspec-stubbed_env.gemspec
+++ b/rspec-stubbed_env.gemspec
@@ -19,18 +19,14 @@ stub_env(
   spec.homepage      = 'https://github.com/pboling/rspec-stubbed_env'
   spec.license       = 'MIT'
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files         = Dir['lib/**/*', 'LICENSE', 'README.md']
   spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rspec', '>= 3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 12.3'
+  spec.add_development_dependency 'rubocop-packaging', '~> 0.1'
   spec.add_development_dependency 'simplecov', '~> 0.16'
 end


### PR DESCRIPTION
Hi @pboling,

Thanks for working on this! :heart: 
However, while maintaining this in Debian, we found that this library relies on `git` to list the files which could be done via pure Ruby alternative -- which is what this PR does.

As an addition, this PR makes sure that this gem only ships the required files to the end users and not other things which are not needed by them :rocket: 

Also, added `rubocop-packaging` as a development_dependency which will ensure the best practices.
Here's what it shows us:
```
➜  rspec-stubbed_env git:(master)  rubocop --only Packaging

Offenses:

rspec-stubbed_env.gemspec:25:5: C: Packaging/GemspecGit: Avoid using git to produce lists of files. Downstreams
often need to build your package in an environment that does not have git (on purpose). Use some pure Ruby
alternative, like Dir or Dir.glob.
    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
    ^^^^^^^^^^^^^^^^^
```

And this PR fixes the same, which helps us in shipping this in Debian! :tada: 
Hope this would make sense and you'll be open to this change :100: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>